### PR TITLE
Explicitly note parallel reads are safe

### DIFF
--- a/sphinxcontrib/redirects/__init__.py
+++ b/sphinxcontrib/redirects/__init__.py
@@ -82,3 +82,7 @@ def generate_redirects(app):
 def setup(app):
     app.add_config_value('redirects_file', 'redirects', 'env')
     app.connect('builder-inited', generate_redirects)
+    return {
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }


### PR DESCRIPTION
When working in a project that treats warnings as errors, the following warning stops a project from being built successfully with this plugin:

`the sphinxcontrib.redirects extension does not declare if it is safe for parallel reading, assuming it isn't - please ask the extension author to check and make it explicit`

This makes it explicit that it supports parallel reads (assuming it does? if not, I can swap to False), which solves the issue. I admittedly don't understand a lot of things going on here, and am mostly stealing this fix from https://github.com/tox-dev/sphinx-autodoc-typehints/commit/c4657bc57a290a79605ed86398db28419aabfbb9 a different project's fix.